### PR TITLE
Objects for Games::TMX::Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Games-TMX-Parser-*
+.build

--- a/README
+++ b/README
@@ -42,11 +42,11 @@ Requires
 
 - Moose
 - XML::Twig
+- Algorithm::Line::Bresenham
 
 
 Not Implemented
 ---------------
 
+- no support for TSX
 - no support for base64 or compression of maps, uncheck the correct check boxes in Tiled before you save
-- no support for object layers
-

--- a/dist.ini
+++ b/dist.ini
@@ -3,9 +3,9 @@ author  = Ran Eilam <eilara@cpan.org>
 license = Perl_5
 
 copyright_holder = Ran Eilam
-copyright_year   = 2011
+copyright_year   = 2012
 
-version = 0.91
+version = 0.92
 
 [GatherDir]
 [PruneCruft]
@@ -24,4 +24,4 @@ version = 0.91
 [Prereqs]
 Moose = 2.0204
 XML::Twig = 3.39
-
+Algorithm::Line::Bresenham = 0.11

--- a/eg/tower_defense.tmx
+++ b/eg/tower_defense.tmx
@@ -1333,4 +1333,17 @@
    <tile gid="0"/>
   </data>
  </layer>
+ <objectgroup name="rooms" width="25" height="17">
+  <object name="room1" x="25" y="25" width="75" height="75"/>
+  <object name="polygon1" x="0" y="275">
+   <polygon points="0,0 150,125 150,0"/>
+  </object>
+  <object name="objecttile1" gid="26" x="50" y="150"/>
+  <object name="polyline1" x="0" y="150">
+   <polyline points="0,0 0,225 75,175 150,250"/>
+  </object>
+  <object name="polygon2" x="350" y="25">
+   <polygon points="0,0 -50,175 200,50 125,200 100,0 100,200 250,275"/>
+  </object>
+ </objectgroup>
 </map>

--- a/t/Games-TMX-Parser.t
+++ b/t/Games-TMX-Parser.t
@@ -5,6 +5,7 @@ use FindBin qw($Bin);
 use Test::More;
 use File::Spec;
 use Games::TMX::Parser;
+use Data::Dumper;
 
 my $parser = Games::TMX::Parser->new(
     map_dir  => File::Spec->catfile($Bin, '..', 'eg'),
@@ -23,5 +24,64 @@ my @leave_cells = $waypoints_layer->find_cells_with_property('leave_point');
 is scalar(@spawn_cells), 1, 'one spawn cell';
 is scalar(@leave_cells), 1, 'one leave cell';
 
-done_testing;
+is $map->tile_height, 25, 'tile_height correct';
+is $map->tile_width, 25, 'tile_width correct';
 
+diag "object group";
+my $obj_group_rooms = $map->get_objectgroup('rooms');
+isa_ok $obj_group_rooms, 'Games::TMX::Parser::ObjectGroup', 'rooms objectgroup exists';
+is scalar(@{ $obj_group_rooms->list_object_names}), 5, 'all four  object types';
+
+diag "rectangular object";
+{
+    my $obj_name = 'room1';
+    my @pos = (2,2);
+    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+    is scalar(@obj), 1, "1 object called $obj_name";
+    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Rectangle', "$obj_name is a rectangle object";
+    is scalar(@{$obj[0]->positions_yx}), 9, "$obj_name is 9 square wide";
+    is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+    is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+    diag $obj[0]->dump_object;
+}
+
+diag "tile object";
+{
+    my $obj_name = 'objecttile1';
+    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+    is scalar(@obj), 1, "1 object called $obj_name";
+    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Tile', "$obj_name is a tile object";
+    is scalar(@{$obj[0]->positions_yx}), 1, "$obj_name is 1 square wide";
+    is_deeply $obj[0]->positions_yx, [[5,2]], "$obj_name is at [5,2]";
+    diag $obj[0]->dump_object;
+}
+
+diag "polyline object";
+{
+    my $obj_name = 'polyline1';
+    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+    is scalar(@obj), 1, "1 object called $obj_name";
+    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Polyline', "$obj_name is a Polyline object";
+    is scalar(@{$obj[0]->positions_yx}), 16, "$obj_name is 16 squares long";
+    diag $obj[0]->dump_object;
+    # warn Dumper $obj[0]->positions_yx;
+    # is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+    # is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+}
+
+diag "polygon object";
+{
+    my $obj_name = 'polygon1';
+    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+    is scalar(@obj), 1, "1 object called $obj_name";
+    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Polygon', "$obj_name is a Polygon object";
+
+    diag $obj[0]->dump_object;
+    # is scalar(@{$obj[0]->positions_yx}), 16, "$obj_name is 16 squares long";
+    # warn Dumper $obj[0]->positions_yx;
+    # is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+    # is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+}
+
+
+done_testing;

--- a/t/foo.t
+++ b/t/foo.t
@@ -1,0 +1,90 @@
+package main;
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use Test::More;
+use File::Spec;
+use Games::TMX::Parser;
+use Data::Dumper;
+$Data::Dumper::Maxdepth = 3;
+
+my $parser = Games::TMX::Parser->new(
+    map_dir  => '/code/perl/textadventure/bin/',
+    map_file => 'untitled.tmx',
+);
+
+my $map = $parser->map;
+
+is scalar(keys %{$map->layers}), 3, 'layer count';
+
+my $base_layer = $map->get_layer('base');
+
+#my @spawn_cells = $waypoints_layer->find_cells_with_property('walkable');
+#my @leave_cells = $waypoints_layer->find_cells_with_property('light');
+#
+#is scalar(@spawn_cells), 600, '600 spawn cell';
+#is scalar(@leave_cells), 600, '600 leave cell';
+
+is $map->tile_height, 52, 'tile_height correct';
+is $map->tile_width, 28, 'tile_width correct';
+
+warn Dumper $base_layer->map->get_tile(23)->properties;
+
+#diag "object group";
+#my $obj_group_rooms = $map->get_objectgroup('rooms');
+#isa_ok $obj_group_rooms, 'Games::TMX::Parser::ObjectGroup', 'rooms objectgroup exists';
+#is scalar(@{ $obj_group_rooms->list_object_names}), 5, 'all four  object types';
+#
+#diag "rectangular object";
+#{
+#    my $obj_name = 'room1';
+#    my @pos = (2,2);
+#    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+#    is scalar(@obj), 1, "1 object called $obj_name";
+#    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Rectangle', "$obj_name is a rectangle object";
+#    is scalar(@{$obj[0]->positions_yx}), 9, "$obj_name is 9 square wide";
+#    is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+#    is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+#    diag $obj[0]->dump_object;
+#}
+#
+#diag "tile object";
+#{
+#    my $obj_name = 'objecttile1';
+#    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+#    is scalar(@obj), 1, "1 object called $obj_name";
+#    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Tile', "$obj_name is a tile object";
+#    is scalar(@{$obj[0]->positions_yx}), 1, "$obj_name is 1 square wide";
+#    is_deeply $obj[0]->positions_yx, [[5,2]], "$obj_name is at [5,2]";
+#    diag $obj[0]->dump_object;
+#}
+#
+#diag "polyline object";
+#{
+#    my $obj_name = 'polyline1';
+#    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+#    is scalar(@obj), 1, "1 object called $obj_name";
+#    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Polyline', "$obj_name is a Polyline object";
+#    is scalar(@{$obj[0]->positions_yx}), 16, "$obj_name is 16 squares long";
+#    diag $obj[0]->dump_object;
+#    # warn Dumper $obj[0]->positions_yx;
+#    # is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+#    # is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+#}
+#
+#diag "polygon object";
+#{
+#    my $obj_name = 'polygon1';
+#    my @obj = $obj_group_rooms->get_objects_by_name($obj_name);
+#    is scalar(@obj), 1, "1 object called $obj_name";
+#    isa_ok ref($obj[0]), 'Games::TMX::Parser::Object::Polygon', "$obj_name is a Polygon object";
+#
+#    diag $obj[0]->dump_object;
+#    # is scalar(@{$obj[0]->positions_yx}), 16, "$obj_name is 16 squares long";
+#    # warn Dumper $obj[0]->positions_yx;
+#    # is scalar(@{$obj_group_rooms->objects_for_position_yx(@pos)}), 1, "There is one object at [@pos]";
+#    # is $obj_group_rooms->objects_for_position_yx( @pos )->[0]->name, 'room1', "The object at [@pos] is room1";
+#}
+#
+#
+#done_testing;


### PR DESCRIPTION
Hi Ran,

I hacked basic object support into the module. I want to use this to define areas within my maps for rooms. As it is now, the coordinates (in terms of tiles, not pixels, as an arrayref [$y, $x]) can be calculated, the objects that are at a specific coordinate can be listed and introspection from map to objectgroup to object and back is possible.

It's probably not very efficient and the polygon fill algorithm isn't perfect, but it's a start.

Best wishes,
Konstantin
