### PR TITLE
Fix an issue reading properties of first tiles

### DIFF
--- a/eg/tower_defense.tmx
+++ b/eg/tower_defense.tmx
@@ -2,6 +2,11 @@
 <map version="1.0" orientation="orthogonal" width="25" height="17" tilewidth="25" tileheight="25">
  <tileset firstgid="1" name="towers" tilewidth="25" tileheight="25">
   <image source="towers.png" width="100" height="75"/>
+  <tile id="0">
+   <properties>
+    <property name="test_tower" value="1"/>
+   </properties>
+  </tile>
  </tileset>
  <tileset firstgid="13" name="tiles" tilewidth="25" tileheight="25">
   <image source="tiles.png" width="100" height="125"/>

--- a/lib/Games/TMX/Parser.pm
+++ b/lib/Games/TMX/Parser.pm
@@ -236,7 +236,7 @@ sub _build_tiles {
     # create a tile object for each tile in the tileset
     # unless it is a tile with properties
     my @tiles;
-    my $it = natatime $self->width, 1..$self->tile_count;
+    my $it = natatime $self->width, 0 .. $self->tile_count - 1;
     while (my @ids = $it->()) {
         for my $id (@ids) {
             my $gid = $first_gid + $id;

--- a/t/property_of_first_tile.t
+++ b/t/property_of_first_tile.t
@@ -1,0 +1,21 @@
+package main;
+
+use strict;
+use warnings;
+
+use FindBin qw($Bin);
+use Test::More;
+use File::Spec;
+use Games::TMX::Parser;
+
+my $map = Games::TMX::Parser->new(
+    map_dir  => File::Spec->catfile($Bin, '..', 'eg'),
+    map_file => 'tower_defense.tmx',
+)->map;
+
+my @test_towers = $map->get_layer('towers')
+    ->find_cells_with_property('test_tower');
+
+is scalar(@test_towers), 3, 'three test towers';
+
+done_testing;


### PR DESCRIPTION
When the first tile of the first tileset has a property, Games::TMX::Parser drops it because it starts counts tiles as `firstgid + ( 1 .. $map->tile_count )`, which means that the first tile (which should have `gid = 1`) was being queried as `gid = 2`.

The fix was very simple. This patch includes a small test to illustrate the problem.