### PR TITLE
Add general support for element properties

### DIFF
--- a/eg/tower_defense.tmx
+++ b/eg/tower_defense.tmx
@@ -1,9 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="25" height="17" tilewidth="25" tileheight="25">
+ <properties>
+  <property name="map-raw" value="1"/>
+  <property name="map-false" type="boolean" value="false"/>
+  <property name="map-true" type="boolean" value="true"/>
+  <property name="map-var" type="string" value="false"/>
+ </properties>
  <tileset firstgid="1" name="towers" tilewidth="25" tileheight="25">
   <image source="towers.png" width="100" height="75"/>
  </tileset>
  <tileset firstgid="13" name="tiles" tilewidth="25" tileheight="25">
+  <properties>
+   <property name="tileset-raw" value="1"/>
+   <property name="tileset-false" type="boolean" value="false"/>
+   <property name="tileset-true" type="boolean" value="true"/>
+   <property name="tileset-var" type="string" value="false"/>
+  </properties>
   <image source="tiles.png" width="100" height="125"/>
   <tile id="12">
    <properties>
@@ -47,6 +59,12 @@
   </tile>
  </tileset>
  <layer name="path" width="25" height="17">
+  <properties>
+   <property name="layer-raw" value="1"/>
+   <property name="layer-false" type="boolean" value="false"/>
+   <property name="layer-true" type="boolean" value="true"/>
+   <property name="layer-var" type="string" value="false"/>
+  </properties>
   <data>
    <tile gid="0"/>
    <tile gid="0"/>

--- a/lib/Games/TMX/Parser.pm
+++ b/lib/Games/TMX/Parser.pm
@@ -166,6 +166,33 @@ has el => (is => 'ro', required => 1, handles => [qw(
     att att_exists first_child children print
 )]);
 
+has properties => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    lazy    => 1,
+    default => sub {
+        return {} unless $_[0]->el;
+
+        my $el = $_[0]->first_child('properties') or return {};
+
+        my %props;
+
+        for ( $el->children ) {
+            my $type = $_->att('type') // '';
+            if ( $type eq 'boolean' ) {
+                $props{ $_->att('name') } = $_->att('value') eq 'true';
+            }
+            else {
+                $props{ $_->att('name') } = $_->att('value');
+            }
+        }
+
+        return \%props;
+    },
+);
+
+sub get_prop { shift->properties->{ +shift } }
+
 # ------------------------------------------------------------------------------
 
 package Games::TMX::Parser::Map;
@@ -222,16 +249,31 @@ sub _build_tiles {
     my $first_gid = $self->first_gid;
 
     # index tiles with properties
-    my $prop_tiles = {map {
-        my $el = $_;
-        my $id = $first_gid + $el->att('id');
-        my $properties = {map {
-           $_->att('name'), $_->att('value') 
-        } $el->first_child('properties')->children};
-        my $tile = Games::TMX::Parser::Tile->new
-            (id => $id, properties => $properties, tileset => $self);
-        ($id => $tile);
-    } $self->children('tile')};
+
+    my %prop_tiles;
+
+    for my $tile ( $self->children('tile') ) {
+        my $id = $first_gid + $tile->att('id');
+        my $el = $tile->first_child('properties') or next;
+
+        my %props;
+
+        for ( $el->children ) {
+            my $type = $_->att('type') // '';
+            if ( $type eq 'boolean' ) {
+                $props{ $_->att('name') } = $_->att('value') eq 'true';
+            }
+            else {
+                $props{ $_->att('name') } = $_->att('value');
+            }
+        }
+
+        $prop_tiles{$id} = Games::TMX::Parser::Tile->new(
+            id         => $id,
+            properties => \%props,
+            tileset    => $self,
+        );
+    }
 
     # create a tile object for each tile in the tileset
     # unless it is a tile with properties
@@ -240,7 +282,7 @@ sub _build_tiles {
     while (my @ids = $it->()) {
         for my $id (@ids) {
             my $gid = $first_gid + $id;
-            my $tile = $prop_tiles->{$gid} || 
+            my $tile = $prop_tiles{$gid} ||
                 Games::TMX::Parser::Tile->new(id => $gid, tileset => $self);
             push @tiles, $tile;
         }

--- a/t/general_properties.t
+++ b/t/general_properties.t
@@ -1,0 +1,46 @@
+package main;
+
+use strict;
+use warnings;
+
+use FindBin qw($Bin);
+use Test::More;
+use File::Spec;
+use Games::TMX::Parser;
+
+my $map = Games::TMX::Parser->new(
+    map_dir  => File::Spec->catfile($Bin, '..', 'eg'),
+    map_file => 'tower_defense.tmx',
+)->map;
+
+is_deeply $map->properties, {
+    'map-raw'   => 1,
+    'map-false' => '',
+    'map-true'  => 1,
+    'map-var'   => 'false',
+};
+
+is $map->get_prop('map-var'), 'false';
+is $map->get_prop('foo'), undef;
+
+is_deeply $map->get_layer('path')->properties, {
+    'layer-raw'   => 1,
+    'layer-false' => '',
+    'layer-true'  => 1,
+    'layer-var'   => 'false',
+};
+
+is $map->get_layer('path')->get_prop('layer-var'), 'false';
+is $map->get_layer('path')->get_prop('foo'), undef;
+
+is_deeply $map->tilesets->[1]->properties, {
+    'tileset-raw'   => 1,
+    'tileset-false' => '',
+    'tileset-true'  => 1,
+    'tileset-var'   => 'false',
+};
+
+is $map->tilesets->[1]->get_prop('tileset-var'), 'false';
+is $map->tilesets->[1]->get_prop('foo'), undef;
+
+done_testing;


### PR DESCRIPTION
According to [the current TMX spec](https://doc.mapeditor.org/en/stable/reference/tmx-map-format), almost all elements can include a `properties` like tiles do in tilesets. This patch adds support for these in MapElement, and by extension in Layer, Map, and TileSet objects.

It implements the same interface currently available in Tile objects, with a `properties` method to get a hasref of properties, and a `get_prop` to get the value of a property by name.

It also includes some validation by property type so that properties that have been given the boolean `false` are not turned into truthy values by Perl. This could use something more involved, like JSON::PP::True and JSON::PP::False, but I thought that was not worth the effort.