### PR TITLE
Add x and y attributes to Tile objects

### DIFF
--- a/lib/Games/TMX/Parser.pm
+++ b/lib/Games/TMX/Parser.pm
@@ -79,7 +79,7 @@ want to read in Perl. Then in your Perl game, read the map and use:
 
     my @cells = $map->get_layer('layer_with_stuff')
                     ->find_cells_with_property('my_special_tile_marker');
- 
+
 To find your special cells (spawn points, enemy locations, etc.).
 
 Draw a layer by iteating over:
@@ -226,7 +226,7 @@ sub _build_tiles {
         my $el = $_;
         my $id = $first_gid + $el->att('id');
         my $properties = {map {
-           $_->att('name'), $_->att('value') 
+           $_->att('name'), $_->att('value')
         } $el->first_child('properties')->children};
         my $tile = Games::TMX::Parser::Tile->new
             (id => $id, properties => $properties, tileset => $self);
@@ -240,7 +240,7 @@ sub _build_tiles {
     while (my @ids = $it->()) {
         for my $id (@ids) {
             my $gid = $first_gid + $id;
-            my $tile = $prop_tiles->{$gid} || 
+            my $tile = $prop_tiles->{$gid} ||
                 Games::TMX::Parser::Tile->new(id => $gid, tileset => $self);
             push @tiles, $tile;
         }
@@ -254,6 +254,7 @@ sub _build_tile_count {
            ($self->tile_width * $self->tile_height);
 }
 
+sub _build_columns     { shift->att('columns') }
 sub _build_first_gid   { shift->att('firstgid') }
 sub _build_tile_width  { shift->att('tilewidth') }
 sub _build_tile_height { shift->att('tileheight') }
@@ -269,6 +270,26 @@ use Moose;
 
 has id      => (is => 'ro', isa => 'Int', required => 1);
 has tileset => (is => 'ro', weak_ref => 1, required => 1);
+
+has 'x' => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $tileset = $_[0]->tileset;
+        my $local_id = $_[0]->id - $tileset->first_gid;
+        return $local_id % $tileset->columns;
+    },
+);
+
+has 'y' => (
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $tileset = $_[0]->tileset;
+        my $local_id = $_[0]->id - $tileset->first_gid;
+        return int( $local_id / $tileset->columns );
+    },
+);
 
 has properties => (is => 'ro', isa => 'HashRef', default => sub { {} });
 

--- a/lib/Games/TMX/Parser.pm
+++ b/lib/Games/TMX/Parser.pm
@@ -199,8 +199,8 @@ sub _build_tilesets {
 
 sub _build_width       { shift->att('width') }
 sub _build_height      { shift->att('height') }
-sub _build_tile_width  { shift->att('tile_width') }
-sub _build_tile_height { shift->att('tile_height') }
+sub _build_tile_width  { shift->att('tilewidth') }
+sub _build_tile_height { shift->att('tileheight') }
 
 sub get_layer { shift->layers->{pop()} }
 sub get_tile  { shift->tiles_by_id->{pop()} }


### PR DESCRIPTION
This adds an `x` and `y` attribute to the Tile class which makes it easier to determine what part of the sprite tilesheet this tile in particular needs to clip. They will be `[ 0, 0 ]` for the tile at the top left, and `[ 1, 0 ]` for the tile immediately to the right.

The clip rectangle for the sprite sheet can then be calculated using the `tile_width` and `tile_height` attributes from the Tileset object.

This includes a fix for these attributes' builders, which had an extra underscore.