### PR TITLE
Add Cell tests and fix hash randomisation

### DIFF
--- a/lib/Games/TMX/Parser.pm
+++ b/lib/Games/TMX/Parser.pm
@@ -342,8 +342,14 @@ has layer => (is => 'ro', required => 1, weak_ref => 1, handles => [qw(
     get_cell width height
 )]);
 
-my %Dirs      = map { $_ => 1 } qw(below left right above);
-my %Anti_Dirs = (below => 'above', left => 'right', right => 'left', above => 'below');
+my @DIRS = qw( left below right above );
+
+my %ANTI_DIRS = (
+    below => 'above',
+    left  => 'right',
+    right => 'left',
+    above => 'below'
+);
 
 sub left  { shift->neighbor(-1, 0) }
 sub right { shift->neighbor( 1, 0) }
@@ -363,13 +369,16 @@ sub neighbor {
 
 sub seek_next_cell {
     my ($self, $dir) = @_;
-    my %dirs = %Dirs;
-    delete $dirs{$Anti_Dirs{$dir}} if $dir;
-    for my $d (keys %dirs) {
-        my $c = $self->$d;
-        return [$c, $d] if $c && $c->tile;
-    }
-    return undef;
-}
 
+    my $opposite = $dir ? $ANTI_DIRS{$dir} : '';
+
+    for my $direction (@DIRS) {
+        next if $direction eq $opposite;
+
+        my $cell = $self->$direction;
+        return [ $cell, $direction ] if $cell && $cell->tile;
+    }
+
+    return;
+}
 1;

--- a/t/cell-directions.t
+++ b/t/cell-directions.t
@@ -1,0 +1,58 @@
+package main;
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use Test::More;
+use File::Spec;
+use Games::TMX::Parser;
+
+my $parser = Games::TMX::Parser->new(
+    map_dir  => File::Spec->catfile($Bin, '..', 'eg'),
+    map_file => 'tower_defense.tmx',
+);
+
+my $map = $parser->map;
+
+subtest 'Directions' => sub {
+    my $layer = $parser->map->get_layer('waypoints');
+
+    my ($spawn) = $layer->find_cells_with_property('spawn_point');
+    my ($leave) = $layer->find_cells_with_property('leave_point');
+
+    is $spawn->x, 3, '->x';
+    is $spawn->y, 0, '->y';
+    is_deeply [ $spawn->xy ], [ 3, 0 ], '->xy';
+    is $spawn->tile->id, 29, 'Cell has tile with right ID';
+
+    is_deeply [ $spawn->left->xy ],  [ 2, 0 ], '$spawn->left';
+    is_deeply [ $spawn->right->xy ], [ 4, 0 ], '$spawn->right';
+    is_deeply [ $spawn->below->xy ], [ 3, 1 ], '$spawn->below';
+    is          $spawn->above,         undef,  '$spawn->above';
+
+    is_deeply [ $leave->left->xy ],  [ 20, 16 ], '$leave->left';
+    is_deeply [ $leave->right->xy ], [ 22, 16 ], '$leave->right';
+    is          $leave->below,         undef,    '$leave->below';
+    is_deeply [ $leave->above->xy ], [ 21, 15 ], '$leave->above';
+};
+
+subtest 'Seek' => sub {
+    my $layer = $parser->map->get_layer('path');
+
+    my @cells;
+    my ($cell)  = $layer->get_cell(  3,  0 );
+
+    my $direction;
+    for ( 0 .. 100 ) {
+        push @cells, $cell;
+
+        ( $cell, $direction ) = @{ $cell->seek_next_cell($direction) // [] }
+            or last;
+    }
+
+    is scalar @cells, 39, 'Right number of cells in path';
+    is_deeply [ $cells[0]->xy ], [ 3, 0 ],    'Correct start';
+    is_deeply [ $cells[12]->xy ], [ 7, 8 ],   'Correct cell after crossroad';
+    is_deeply [ $cells[38]->xy ], [ 21, 16 ], 'Correct end';
+};
+
+done_testing;


### PR DESCRIPTION
Games::TMX::Parser::Cell objects relied on a consistent hash key order, which is no longer guarranteed after Perl 5.18.

This reimplements the seek_next_cell method so it will continue to work on newer versions of Perl, and adds tests for that and other Cell methods, which were not being covered.